### PR TITLE
added missing dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "classnames": "^2.2.0",
     "express": "^4.13.3",
     "gulp": "^3.9.0",
+    "gulp-less": "^3.1.0",
+    "gulp-rename": "^1.2.2",
     "lodash": "^4.11.2",
     "marked": "^0.3.5",
     "moment": "^2.11.0",


### PR DESCRIPTION
You were not able to do `npm install` and the rest of the setup process.
Added dependencies `gulp-rename` and `gulp-less`

OS: OSX El Capitan
node version: 4.5.0