### PR TITLE
Parse markdown only once.

### DIFF
--- a/shared/homebrewery/markdown.js
+++ b/shared/homebrewery/markdown.js
@@ -10,7 +10,7 @@ renderer.paragraph = function(text){
 	if(!matches) return `\n<p>${text}</p>\n`;
 	let matchIndex = 0;
 	const res =  _.reduce(text.split(blockReg), (r, text) => {
-		if(text) r.push(Markdown(text, {renderer : renderer, sanitize: true}));
+		if(text) r.push(text);
 		const block = matches[matchIndex];
 		if(block && block[0] == '{'){
 			r.push(`\n\n<div class="block ${block.substring(2).split(',').join(' ')}">`);


### PR DESCRIPTION
By the time `marked` invokes the `renderer.paragraph` callback, it has already processed the content and translated anything it could parse to HTML. After splitting on block markers, we should therefore avoid re-parsing the content as (sanitized) Markdown), because that will escape the HTML markup produced by the initial parse.

To see the problem, try a brew like this:

```
{{test
![Goblin](http://i.imgur.com/ET6Hp6D.png)
}}
```

Without this change, the `<img...>` tag produced by the first parse is escaped into `&lt;img...`, and therefore the image is not displayed. After the patch, the image renders as expected.

-------
I ran into this while investigating a port of #348 onto the v3 branch.