### PR TITLE
Fix aside being rejected as unclosed link

### DIFF
--- a/shared/naturalcrit/markdown.js
+++ b/shared/naturalcrit/markdown.js
@@ -17,7 +17,7 @@ renderer.html = function (html) {
 const tagTypes = ['div', 'span', 'a'];
 const tagRegex = new RegExp('(' +
 	_.map(tagTypes, (type)=>{
-		return `\\<${type}|\\</${type}>`;
+		return `\\<${type}\\b|\\</${type}>`;
 	}).join('|') + ')', 'g');
 
 
@@ -79,4 +79,3 @@ module.exports = {
 		return errors;
 	},
 };
-


### PR DESCRIPTION
The current RegExp for validating HTML gets derived into includes this
value:

```
/(\<div|\<\/div>|\<span|\<\/span>|\<a|\<\/a>)/g
```

However, this leads to the following match on an `<aside />` element:

```
> ('<aside>foo</aside>').match(tagRegex)
[ '<a' ]
```

...which looks to homebrewery like an unclosed `<a />` element. This new
RegExp ensures that open tags are always matched with closing tags of
the same type.