### PR TITLE
Fix Partial Page Rendering hiding the current page on longer documents

### DIFF
--- a/client/homebrew/brewRenderer/brewRenderer.jsx
+++ b/client/homebrew/brewRenderer/brewRenderer.jsx
@@ -78,13 +78,8 @@ const BrewRenderer = createClass({
 		if(!this.state.isMounted) return false;
 
 		const viewIndex = this.state.viewablePageNumber;
-		if(index == viewIndex - 3) return true;
-		if(index == viewIndex - 2) return true;
-		if(index == viewIndex - 1) return true;
-		if(index == viewIndex)     return true;
-		if(index == viewIndex + 1) return true;
-		if(index == viewIndex + 2) return true;
-		if(index == viewIndex + 3) return true;
+
+		if(Math.abs(viewIndex - index) < 10) return true;
 
 		//Check for style tages
 		if(pageText.indexOf('<style>') !== -1) return true;


### PR DESCRIPTION
Problem: On large documents `this.state.viewablePageNumber` becomes out of sync with `viewIndex` as seen:

![ppr](https://user-images.githubusercontent.com/235857/39048730-c2140746-449e-11e8-813e-293318d2fe16.JPG)

This PR temporarily increases the limit of pages shown to 10 so that large projects can see the current page. Otherwise it's just a spinner. The performance is marginally impacted, but that has less consequences than users not being able to use homebrewery imo

This can be changed at a later point when PPR is fixed, but currently homebrewery cannot handle a large amount of pages.