### PR TITLE
Config: Read MongoDB URL from config files too.

### DIFF
--- a/server.js
+++ b/server.js
@@ -15,7 +15,7 @@ const config = require('nconf')
 
 //DB
 const mongoose = require('mongoose');
-mongoose.connect(process.env.MONGODB_URI || process.env.MONGOLAB_URI || 'mongodb://localhost/naturalcrit');
+mongoose.connect(config.get('mongodb_uri') || config.get('mongolab_uri') || 'mongodb://localhost/naturalcrit');
 mongoose.connection.on('error', ()=>{
 	console.log('Error : Could not connect to a Mongo Database.');
 	console.log('        If you are running locally, make sure mongodb.exe is running.');


### PR DESCRIPTION
This turned out to be useful in some local work. By reading the MongoDB URLs via `nconfig`, we gain the ability to specify them on the command line or in config files -- while still respecting the previous environment variables, so that the patch hopefully does not break anybody's setup.