### PR TITLE
Reduce repaints on scroll

### DIFF
--- a/client/homebrew/brewRenderer/brewRenderer.jsx
+++ b/client/homebrew/brewRenderer/brewRenderer.jsx
@@ -25,6 +25,7 @@ const BrewRenderer = createClass({
 		return {
 			viewablePageNumber : 0,
 			height             : 0,
+			willChange		   : 'auto',
 			isMounted          : false,
 
 			usePPR : true,
@@ -132,22 +133,43 @@ const BrewRenderer = createClass({
 		});
 		return this.lastRender;
 	},
+	
+	/**
+	*	Optimize for smooth scrolling when mouse enters the rendering panel 
+	**/
+	prepareScroll : function(){
+		this.setState({willChange : 'transform'});
+	},
+	
+	/**
+	*	Unload smooth scrolling optimizations when mouse leaves rendering panel
+	**/
+	unprepareScroll : function(){
+		this.setState({willChange : 'auto'});
+	},
 
 	render : function(){
-		return <div className='brewRenderer'
-			onScroll={this.handleScroll}
-			ref='main'
-			style={{ height: this.state.height }}>
+		return (
+			<React.Fragment>
+				<div className='brewRenderer'
+					onScroll={this.handleScroll}
+					onMouseOver={this.prepareScroll}
+					onMouseOut={this.unprepareScroll}
+					ref='main'
+					style={{ height: 	 this.state.height,
+							 willChange: this.state.willChange}}>
 
-			<ErrorBar errors={this.props.errors} />
-			<RenderWarnings />
+					<ErrorBar errors={this.props.errors} />
+					<RenderWarnings />
 
-			<div className='pages' ref='pages'>
-				{this.renderPages()}
-			</div>
-			{this.renderPageInfo()}
-			{this.renderPPRmsg()}
-		</div>;
+					<div className='pages' ref='pages'>
+						{this.renderPages()}
+					</div>
+				</div>;
+				{this.renderPageInfo()}
+				{this.renderPPRmsg()}
+			</React.Fragment>
+		);
 	}
 });
 

--- a/client/homebrew/brewRenderer/brewRenderer.jsx
+++ b/client/homebrew/brewRenderer/brewRenderer.jsx
@@ -25,7 +25,7 @@ const BrewRenderer = createClass({
 		return {
 			viewablePageNumber : 0,
 			height             : 0,
-			willChange		   : 'auto',
+			willChange         : 'auto',
 			isMounted          : false,
 
 			usePPR : true,
@@ -133,19 +133,19 @@ const BrewRenderer = createClass({
 		});
 		return this.lastRender;
 	},
-	
+
 	/**
-	* Optimize for smooth scrolling when mouse enters the rendering panel 
+	* Optimize for smooth scrolling when mouse enters the rendering panel
 	**/
 	prepareScroll : function(){
-		this.setState({willChange : 'transform'});
+		this.setState({ willChange: 'transform' });
 	},
-	
+
 	/**
 	* Unload smooth scrolling optimizations when mouse leaves rendering panel
 	**/
 	unprepareScroll : function(){
-		this.setState({willChange : 'auto'});
+		this.setState({ willChange: 'auto' });
 	},
 
 	render : function(){
@@ -157,7 +157,7 @@ const BrewRenderer = createClass({
 					onMouseOut={this.unprepareScroll}
 					ref='main'
 					style={{ height: 	 this.state.height,
-							 willChange: this.state.willChange}}>
+							 willChange: this.state.willChange }}>
 
 					<ErrorBar errors={this.props.errors} />
 					<RenderWarnings />

--- a/client/homebrew/brewRenderer/brewRenderer.jsx
+++ b/client/homebrew/brewRenderer/brewRenderer.jsx
@@ -135,14 +135,14 @@ const BrewRenderer = createClass({
 	},
 	
 	/**
-	*	Optimize for smooth scrolling when mouse enters the rendering panel 
+	* Optimize for smooth scrolling when mouse enters the rendering panel 
 	**/
 	prepareScroll : function(){
 		this.setState({willChange : 'transform'});
 	},
 	
 	/**
-	*	Unload smooth scrolling optimizations when mouse leaves rendering panel
+	* Unload smooth scrolling optimizations when mouse leaves rendering panel
 	**/
 	unprepareScroll : function(){
 		this.setState({willChange : 'auto'});

--- a/client/homebrew/brewRenderer/brewRenderer.jsx
+++ b/client/homebrew/brewRenderer/brewRenderer.jsx
@@ -156,8 +156,8 @@ const BrewRenderer = createClass({
 					onMouseOver={this.prepareScroll}
 					onMouseOut={this.unprepareScroll}
 					ref='main'
-					style={{ height: 	 this.state.height,
-							 willChange: this.state.willChange }}>
+					style={{ height     : this.state.height,
+							 willChange : this.state.willChange }}>
 
 					<ErrorBar errors={this.props.errors} />
 					<RenderWarnings />

--- a/client/homebrew/brewRenderer/brewRenderer.less
+++ b/client/homebrew/brewRenderer/brewRenderer.less
@@ -5,28 +5,6 @@
 }
 .brewRenderer{
 	overflow-y : scroll;
-	.pageInfo{
-		position         : absolute;
-		right            : 17px;
-		bottom           : 0;
-		z-index          : 1000;
-		padding          : 8px 10px;
-		background-color : #333;
-		font-size        : 10px;
-		font-weight      : 800;
-		color            : white;
-	}
-	.ppr_msg{
-		position         : absolute;
-		left             : 0px;
-		bottom           : 0;
-		z-index          : 1000;
-		padding          : 8px 10px;
-		background-color : #333;
-		font-size        : 10px;
-		font-weight      : 800;
-		color            : white;
-	}
 	.pages{
 		margin : 30px 0px;
 		&>.phb{
@@ -36,4 +14,26 @@
 			box-shadow    : 1px 4px 14px #000;
 		}
 	}
+}
+.pageInfo{
+	position         : absolute;
+	right            : 17px;
+	bottom           : 0;
+	z-index          : 1000;
+	padding          : 8px 10px;
+	background-color : #333;
+	font-size        : 10px;
+	font-weight      : 800;
+	color            : white;
+}
+.ppr_msg{
+	position         : absolute;
+	left             : 0px;
+	bottom           : 0;
+	z-index          : 1000;
+	padding          : 8px 10px;
+	background-color : #333;
+	font-size        : 10px;
+	font-weight      : 800;
+	color            : white;
 }


### PR DESCRIPTION
The `will-change` property allows the browser to optimize for smoother animations. This completely eliminates the scrolling stutter. Give it a whirl.

Had pull the page count and partial-page notification out of the BrewRenderer div because `will-change` messes up absolute positioning of child elements.