### PR TITLE
Fix duplicated text from Class Feature snippet

### DIFF
--- a/client/homebrew/editor/snippetbar/snippetbar.jsx
+++ b/client/homebrew/editor/snippetbar/snippetbar.jsx
@@ -7,7 +7,9 @@ const cx    = require('classnames');
 const Snippets = require('./snippets/snippets.js');
 
 const execute = function(val, brew){
-	if(_.isFunction(val)) return val(brew);
+	if(snippet.name == 'Table of Contents')
+		return val(brew);
+	else if(_.isFunction(val)) return val();
 	return val;
 };
 


### PR DESCRIPTION
When adding the Class Feature snippet, all curent text in the document is inserted in place of the randomly generated class name, creating several duplicates of the document and generally creating a mess.  See #413 which was closed but the issue was never fixed.

Most of the snippet code generators do not have any input arguments in the `module.exports` function, so they don't have this issue. However, Table of Contents needs to parse the text in the brew, so it is passed a copy of the brew document. Unfortunately, Class Feature (classfeature.gen.js) also has an input parameter for when it is used as part of the Full Class snippet.  Thus, the unintended consequence occurs in snippetbar.jsx in the `execute` function.

This fix simply adds a check to the execute function and only passes in the brew as an argument if the clicked snipped actually is the Table of Contents. Some restructuring might later reveal a cleaner way to do this rather than an awkward special case check like this.