### PR TITLE
Revert "Fix duplicated text from Class Feature snippet"

### DIFF
--- a/client/homebrew/editor/snippetbar/snippetbar.jsx
+++ b/client/homebrew/editor/snippetbar/snippetbar.jsx
@@ -7,9 +7,7 @@ const cx    = require('classnames');
 const Snippets = require('./snippets/snippets.js');
 
 const execute = function(val, brew){
-	if(snippet.name == 'Table of Contents')
-		return val(brew);
-	else if(_.isFunction(val)) return val();
+	if(_.isFunction(val)) return val(brew);
 	return val;
 };
 


### PR DESCRIPTION
Reverts stolksdorf/homebrewery#687

I hadn't rebuilt the bundle when I tested this. :-( It actually breaks all snippets, because `snippet.name` causes an exception -- `snippet` is undefined at that point.

@calculuschild, I'm also confused, because I don't see the duplication you described. Indeed `classfeature.gen.js` takes an argument, but [it is immediately overwritten](https://github.com/stolksdorf/homebrewery/blob/9519a0b4e4b6b4ecb06bb1fa45017112a8b95ec3/client/homebrew/editor/snippetbar/snippets/classfeature.gen.js#L5), so I don't think it can be responsible (on master) for the problem.

I'll merge this PR immediately, because it's a simple revert of something that breaks master.