### PR TITLE
Fix dupliate text from class feature snippet

### DIFF
--- a/client/homebrew/editor/snippetbar/snippetbar.jsx
+++ b/client/homebrew/editor/snippetbar/snippetbar.jsx
@@ -7,7 +7,9 @@ const cx    = require('classnames');
 const Snippets = require('./snippets/snippets.js');
 
 const execute = function(val, brew){
-	if(_.isFunction(val)) return val(brew);
+	if(snippet.name == 'Table of Contents')
+		return val(brew);
+	else if(_.isFunction(val)) return val();
 	return val;
 };
 

--- a/client/homebrew/editor/snippetbar/snippetbar.jsx
+++ b/client/homebrew/editor/snippetbar/snippetbar.jsx
@@ -6,8 +6,8 @@ const cx    = require('classnames');
 
 const Snippets = require('./snippets/snippets.js');
 
-const execute = function(val, brew){
-	if(_.isFunction(val)) return val(brew);
+const execute = function(val, arg){
+	if(_.isFunction(val)) return val(arg);
 	return val;
 };
 

--- a/client/homebrew/editor/snippetbar/snippetbar.jsx
+++ b/client/homebrew/editor/snippetbar/snippetbar.jsx
@@ -7,7 +7,7 @@ const cx    = require('classnames');
 const Snippets = require('./snippets/snippets.js');
 
 const execute = function(val, brew){
-	if(_.isFunction(val)) return val();
+	if(_.isFunction(val)) return val(brew);
 	return val;
 };
 

--- a/client/homebrew/editor/snippetbar/snippetbar.jsx
+++ b/client/homebrew/editor/snippetbar/snippetbar.jsx
@@ -7,9 +7,7 @@ const cx    = require('classnames');
 const Snippets = require('./snippets/snippets.js');
 
 const execute = function(val, brew){
-	if(snippet.name == 'Table of Contents')
-		return val(brew);
-	else if(_.isFunction(val)) return val();
+	if(_.isFunction(val)) return val();
 	return val;
 };
 
@@ -71,7 +69,10 @@ const SnippetGroup = createClass({
 		};
 	},
 	handleSnippetClick : function(snippet){
-		this.props.onSnippetClick(execute(snippet.gen, this.props.brew));
+		let arg = null;
+		if(snippet.name == 'Table of Contents;')
+			arg = this.props.brew;
+		this.props.onSnippetClick(execute(snippet.gen, arg));
 	},
 	renderSnippets : function(){
 		return _.map(this.props.snippets, (snippet)=>{


### PR DESCRIPTION
Reimplementation of stolksdorf/homebrewery#687 which had a small error.

Nearly identical fix; just moved the special case check so `snippet.name` is in scope.

@Rae2che5 Could you verify that the bug does exist? I am seeing it both on the live site and on master.

> To see the duplication issue, try typing something like "chicken nugget" into an empty brew document. Then, add in a "Class Feature" from the snippet bar. You should see a couple places in the generated text where you would expect "actuary" or whatever (*"As an **[actuary]** you gain the following class features..."*), but instead it will say "chicken nugget". Now add another Class Feature. You should have a giant mess with multiple copies of the previous text, which now includes the first "Class Feature" you made, embedded within the new Class Feature.

![image](https://user-images.githubusercontent.com/5878534/39951678-0d469f00-555a-11e8-8e84-258bb3e0c50e.png)
