### PR TITLE
Fix border-image bug on PDFs

### DIFF
--- a/client/homebrew/phbStyle/phb.style.less
+++ b/client/homebrew/phbStyle/phb.style.less
@@ -402,7 +402,7 @@ body {
 	border              : initial;
 	border-style        : solid;
 	border-image-outset : 25px 17px;
-	border-image-repeat : round;
+	border-image-repeat : stretch;
 	border-image-slice  : 150 200 150 200;
 	border-image-source : @frameBorderImage;
 	border-image-width  : 47px;
@@ -410,9 +410,9 @@ body {
 		margin-bottom : 10px;
 	}
 }
-//*****************************
-// *       CLASS TABLE
-// *****************************/
+//************************************
+// *       DESCRIPTIVE TEXT BOX
+// ************************************/
 .phb .descriptive{
 	display             : block-inline;
 	margin-bottom       : 1em;
@@ -420,7 +420,7 @@ body {
 	font-family         : ScalySans;
 	border-style        : solid;
 	border-width        : 7px;
-	border-image        : @descriptiveBoxImage 12 round;
+	border-image        : @descriptiveBoxImage 12 stretch;
 	border-image-outset : 4px;
 	box-shadow          : 0px 0px 6px #faf7ea;
 	p{


### PR DESCRIPTION
I think this might be caused by a new bug in Chrome or something since it seems to have popped up in GMBinder as well in the last couple weeks. See #683

Anyway, the error only occurs on the Class Table and Descriptive Text Box, which are also the only ones to use `border-image-repeat: round`. I changed it to `border-image-repeat: stretch` which solves the graphical issue and doesn't affect the appearance otherwise in this particular case.