### PR TITLE
Fix regression with Pico-Router update

### DIFF
--- a/client/homebrew/homebrew.jsx
+++ b/client/homebrew/homebrew.jsx
@@ -82,7 +82,7 @@ const Homebrew = createClass({
 	},
 	render : function(){
 		return <div className='homebrew'>
-			<Router initialUrl={this.props.url}/>
+			<Router defaultUrl={this.props.url}/>
 		</div>;
 	}
 });

--- a/client/homebrew/phbStyle/phb.style.less
+++ b/client/homebrew/phbStyle/phb.style.less
@@ -402,7 +402,7 @@ body {
 	border              : initial;
 	border-style        : solid;
 	border-image-outset : 25px 17px;
-	border-image-repeat : round;
+	border-image-repeat : stretch;
 	border-image-slice  : 150 200 150 200;
 	border-image-source : @frameBorderImage;
 	border-image-width  : 47px;
@@ -410,9 +410,9 @@ body {
 		margin-bottom : 10px;
 	}
 }
-//*****************************
-// *       CLASS TABLE
-// *****************************/
+//************************************
+// *       DESCRIPTIVE TEXT BOX
+// ************************************/
 .phb .descriptive{
 	display             : block-inline;
 	margin-bottom       : 1em;
@@ -420,7 +420,7 @@ body {
 	font-family         : ScalySans;
 	border-style        : solid;
 	border-width        : 7px;
-	border-image        : @descriptiveBoxImage 12 round;
+	border-image        : @descriptiveBoxImage 12 stretch;
 	border-image-outset : 4px;
 	box-shadow          : 0px 0px 6px #faf7ea;
 	p{


### PR DESCRIPTION
This variable name changed with the v2.0.0 of Pico-Router and it wasn't changed here (commit [55c5294](https://github.com/stolksdorf/homebrewery/commit/55c529473a8b85f6f27eb8769ef7bcfb854827b8#diff-b9cfc7f2cdf78a7f4b91a753d10865a2)). This was causing every page to display a `<div class="homePage page">` rather than the appropriate `editPage` or `sharePage`. It just wasn't immediately noticeable since `homePage` and `editPage` are almost identical. The problem is clearly visible on `sharePage` however. See #695 .

`homebrew.jsx` was set to always render a defaultUrl of ` ` (empty string) which creates a `<div class="homePage page">` by default, overwriting the expected `<div>` on for the current url.

This is the only regression I have seen, and we have added several helpful fixes. What do we think about moving forward with a new release?