### PR TITLE
LGTM.com fixes

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -44,7 +44,6 @@ module.exports = {
 		'arrow-parens'    : ['warn', 'always'],
 		'brace-style'     : ['warn', '1tbs', { allowSingleLine: true }],
 		'jsx-quotes'      : ['warn', 'prefer-single'],
-		'linebreak-style' : ['warn', 'unix'],
 		'no-var'          : 'warn',
 		'prefer-const'    : 'warn',
 		'prefer-template' : 'warn',

--- a/client/admin/homebrewAdmin/brewLookup/brewLookup.jsx
+++ b/client/admin/homebrewAdmin/brewLookup/brewLookup.jsx
@@ -47,8 +47,8 @@ const BrewLookup = createClass({
 		return <div className='brewRow'>
 			<div>{brew.title}</div>
 			<div>{brew.authors.join(', ')}</div>
-			<div><a href={`/edit/${brew.editId}`} target='_blank'>/edit/{brew.editId}</a></div>
-			<div><a href={`/share/${brew.shareId}`} target='_blank'>/share/{brew.shareId}</a></div>
+			<div><a href={`/edit/${brew.editId}`} target='_blank' rel='noopener noreferrer'>/edit/{brew.editId}</a></div>
+			<div><a href={`/share/${brew.shareId}`} target='_blank' rel='noopener noreferrer'>/share/{brew.shareId}</a></div>
 			<div>{Moment(brew.updatedAt).fromNow()}</div>
 			<div>{brew.views}</div>
 		</div>;

--- a/client/admin/homebrewAdmin/brewSearch.jsx
+++ b/client/admin/homebrewAdmin/brewSearch.jsx
@@ -17,16 +17,11 @@ const BrewSearch = createClass({
 		return {
 			searchTerm : '',
 			brew       : null,
-			searching  : false
 		};
 	},
 
 
 	search : function(){
-		this.setState({
-			searching : true
-		});
-
 		request.get(`/homebrew/api/search?id=${this.state.searchTerm}`)
 			.query({
 				admin_key : this.props.admin_key,
@@ -35,8 +30,6 @@ const BrewSearch = createClass({
 				console.log(err, res, res.body.brews[0]);
 				this.setState({
 					brew : res.body.brews[0],
-
-					searching : false
 				});
 			});
 	},

--- a/client/admin/homebrewAdmin/homebrewAdmin.jsx
+++ b/client/admin/homebrewAdmin/homebrewAdmin.jsx
@@ -38,9 +38,10 @@ const HomebrewAdmin = createClass({
 			})
 			.end((err, res)=>{
 				if(err || !res.body || !res.body.brews) return;
-				this.state.brewCache[page] = res.body.brews;
+				const newCache = _.extend({}, this.state.brewCache);
+				newCache[page] = res.body.brews;
 				this.setState({
-					brewCache : this.state.brewCache,
+					brewCache : newCache,
 					total     : res.body.total,
 					count     : res.body.count
 				});

--- a/client/admin/homebrewAdmin/homebrewAdmin.jsx
+++ b/client/admin/homebrewAdmin/homebrewAdmin.jsx
@@ -107,8 +107,8 @@ const HomebrewAdmin = createClass({
 		const brews = this.state.brewCache[this.state.page] || _.times(this.state.count);
 		return _.map(brews, (brew)=>{
 			return <tr className={cx('brewRow', { 'isEmpty': brew.text == 'false' })} key={brew.shareId || brew}>
-				<td><a href={`/edit/${brew.editId}`} target='_blank'>{brew.editId}</a></td>
-				<td><a href={`/share/${brew.shareId}`} target='_blank'>{brew.shareId}</a></td>
+				<td><a href={`/edit/${brew.editId}`} target='_blank' rel='noopener noreferrer'>{brew.editId}</a></td>
+				<td><a href={`/share/${brew.shareId}`} target='_blank' rel='noopener noreferrer'>{brew.shareId}</a></td>
 				<td>{Moment(brew.createdAt).fromNow()}</td>
 				<td>{Moment(brew.updatedAt).fromNow()}</td>
 				<td>{Moment(brew.lastViewed).fromNow()}</td>

--- a/client/admin/homebrewAdmin/homebrewAdmin.jsx
+++ b/client/admin/homebrewAdmin/homebrewAdmin.jsx
@@ -23,8 +23,6 @@ const HomebrewAdmin = createClass({
 			count     : 20,
 			brewCache : {},
 			total     : 0,
-
-			processingOldBrews : false
 		};
 	},
 

--- a/client/homebrew/brewRenderer/brewRenderer.jsx
+++ b/client/homebrew/brewRenderer/brewRenderer.jsx
@@ -27,8 +27,6 @@ const BrewRenderer = createClass({
 			height             : 0,
 			isMounted          : false,
 
-			usePPR : true,
-
 			pages  : pages,
 			usePPR : pages.length >= PPR_THRESHOLD,
 

--- a/client/homebrew/brewRenderer/brewRenderer.jsx
+++ b/client/homebrew/brewRenderer/brewRenderer.jsx
@@ -29,8 +29,6 @@ const BrewRenderer = createClass({
 
 			pages  : pages,
 			usePPR : pages.length >= PPR_THRESHOLD,
-
-			errors : []
 		};
 	},
 	height     : 0,

--- a/client/homebrew/brewRenderer/brewRenderer.jsx
+++ b/client/homebrew/brewRenderer/brewRenderer.jsx
@@ -62,9 +62,9 @@ const BrewRenderer = createClass({
 	},
 
 	handleScroll : function(e){
-		this.setState({
-			viewablePageNumber : Math.floor(e.target.scrollTop / e.target.scrollHeight * this.state.pages.length)
-		});
+		this.setState((prevState)=>({
+			viewablePageNumber : Math.floor(e.target.scrollTop / e.target.scrollHeight * prevState.pages.length)
+		}));
 	},
 
 	shouldRender : function(pageText, index){

--- a/client/homebrew/editor/metadataEditor/metadataEditor.jsx
+++ b/client/homebrew/editor/metadataEditor/metadataEditor.jsx
@@ -118,7 +118,7 @@ const MetadataEditor = createClass({
 		return <div className='field reddit'>
 			<label>reddit</label>
 			<div className='value'>
-				<a href={this.getRedditLink()} target='_blank'>
+				<a href={this.getRedditLink()} target='_blank' rel='noopener noreferrer'>
 					<button className='publish'>
 						<i className='fa fa-reddit-alien' /> share to reddit
 					</button>

--- a/client/homebrew/navbar/recent.navitem.jsx
+++ b/client/homebrew/navbar/recent.navitem.jsx
@@ -59,7 +59,7 @@ const BaseItem = createClass({
 		if(!this.state.showDropdown) return null;
 
 		const items = _.map(this.state.brews, (brew)=>{
-			return <a href={brew.url} className='item' key={brew.id} target='_blank'>
+			return <a href={brew.url} className='item' key={brew.id} target='_blank' rel='noopener noreferrer'>
 				<span className='title'>{brew.title}</span>
 				<span className='time'>{Moment(brew.ts).fromNow()}</span>
 			</a>;
@@ -172,7 +172,7 @@ module.exports = {
 
 			const makeItems = (brews)=>{
 				return _.map(brews, (brew)=>{
-					return <a href={brew.url} className='item' key={brew.id} target='_blank'>
+					return <a href={brew.url} className='item' key={brew.id} target='_blank' rel='noopener noreferrer'>
 						<span className='title'>{brew.title}</span>
 						<span className='time'>{Moment(brew.ts).fromNow()}</span>
 					</a>;

--- a/client/homebrew/pages/editPage/editPage.jsx
+++ b/client/homebrew/pages/editPage/editPage.jsx
@@ -112,12 +112,8 @@ const EditPage = createClass({
 	},
 
 	hasChanges : function(){
-		if(this.savedBrew){
-			return !_.isEqual(this.state.brew, this.savedBrew);
-		} else {
-			return !_.isEqual(this.state.brew, this.props.brew);
-		}
-		return false;
+		const savedBrew = this.savedBrew ? this.savedBrew : this.props.brew;
+		return !_.isEqual(this.state.brew, savedBrew);
 	},
 
 	trySave : function(){

--- a/client/homebrew/pages/editPage/editPage.jsx
+++ b/client/homebrew/pages/editPage/editPage.jsx
@@ -165,7 +165,8 @@ const EditPage = createClass({
 				Oops!
 				<div className='errorContainer'>
 					Looks like there was a problem saving. <br />
-					Report the issue <a target='_blank' href={`https://github.com/stolksdorf/naturalcrit/issues/new?body=${encodeURIComponent(errMsg)}`}>
+					Report the issue <a target='_blank' rel='noopener noreferrer'
+							href={`https://github.com/stolksdorf/naturalcrit/issues/new?body=${encodeURIComponent(errMsg)}`}>
 						here
 					</a>.
 				</div>

--- a/client/homebrew/pages/editPage/editPage.jsx
+++ b/client/homebrew/pages/editPage/editPage.jsx
@@ -45,10 +45,10 @@ const EditPage = createClass({
 		return {
 			brew : this.props.brew,
 
-			isSaving    : false,
-			isPending   : false,
-			errors      : null,
-			htmlErrors  : Markdown.validate(this.props.brew.text),
+			isSaving   : false,
+			isPending  : false,
+			errors     : null,
+			htmlErrors : Markdown.validate(this.props.brew.text),
 		};
 	},
 	savedBrew : null,
@@ -144,8 +144,8 @@ const EditPage = createClass({
 				} else {
 					this.savedBrew = res.body;
 					this.setState({
-						isPending   : false,
-						isSaving    : false,
+						isPending : false,
+						isSaving  : false,
 					});
 				}
 			});

--- a/client/homebrew/pages/editPage/editPage.jsx
+++ b/client/homebrew/pages/editPage/editPage.jsx
@@ -62,7 +62,7 @@ const EditPage = createClass({
 			}
 		};
 
-		this.setState((prevState) => ({
+		this.setState((prevState)=>({
 			htmlErrors : Markdown.validate(prevState.brew.text)
 		}));
 
@@ -128,7 +128,7 @@ const EditPage = createClass({
 	save : function(){
 		if(this.debounceSave && this.debounceSave.cancel) this.debounceSave.cancel();
 
-		this.setState((prevState) => ({
+		this.setState((prevState)=>({
 			isSaving   : true,
 			errors     : null,
 			htmlErrors : Markdown.validate(prevState.brew.text)
@@ -166,7 +166,7 @@ const EditPage = createClass({
 				<div className='errorContainer'>
 					Looks like there was a problem saving. <br />
 					Report the issue <a target='_blank' rel='noopener noreferrer'
-							href={`https://github.com/stolksdorf/naturalcrit/issues/new?body=${encodeURIComponent(errMsg)}`}>
+						href={`https://github.com/stolksdorf/naturalcrit/issues/new?body=${encodeURIComponent(errMsg)}`}>
 						here
 					</a>.
 				</div>

--- a/client/homebrew/pages/editPage/editPage.jsx
+++ b/client/homebrew/pages/editPage/editPage.jsx
@@ -49,7 +49,6 @@ const EditPage = createClass({
 			isPending   : false,
 			errors      : null,
 			htmlErrors  : Markdown.validate(this.props.brew.text),
-			lastUpdated : this.props.brew.updatedAt
 		};
 	},
 	savedBrew : null,
@@ -147,7 +146,6 @@ const EditPage = createClass({
 					this.setState({
 						isPending   : false,
 						isSaving    : false,
-						lastUpdated : res.body.updatedAt
 					});
 				}
 			});

--- a/client/homebrew/pages/editPage/editPage.jsx
+++ b/client/homebrew/pages/editPage/editPage.jsx
@@ -62,9 +62,9 @@ const EditPage = createClass({
 			}
 		};
 
-		this.setState({
-			htmlErrors : Markdown.validate(this.state.brew.text)
-		});
+		this.setState((prevState) => ({
+			htmlErrors : Markdown.validate(prevState.brew.text)
+		}));
 
 		document.addEventListener('keydown', this.handleControlKeys);
 	},
@@ -91,10 +91,10 @@ const EditPage = createClass({
 	},
 
 	handleMetadataChange : function(metadata){
-		this.setState({
-			brew      : _.merge({}, this.state.brew, metadata),
+		this.setState((prevState)=>({
+			brew      : _.merge({}, prevState.brew, metadata),
 			isPending : true,
-		}, ()=>{
+		}), ()=>{
 			this.trySave();
 		});
 
@@ -106,11 +106,11 @@ const EditPage = createClass({
 		let htmlErrors = this.state.htmlErrors;
 		if(htmlErrors.length) htmlErrors = Markdown.validate(text);
 
-		this.setState({
-			brew       : _.merge({}, this.state.brew, { text: text }),
+		this.setState((prevState)=>({
+			brew       : _.merge({}, prevState.brew, { text: text }),
 			isPending  : true,
 			htmlErrors : htmlErrors
-		});
+		}));
 
 		this.trySave();
 	},
@@ -136,11 +136,11 @@ const EditPage = createClass({
 	save : function(){
 		if(this.debounceSave && this.debounceSave.cancel) this.debounceSave.cancel();
 
-		this.setState({
+		this.setState((prevState) => ({
 			isSaving   : true,
 			errors     : null,
-			htmlErrors : Markdown.validate(this.state.brew.text)
-		});
+			htmlErrors : Markdown.validate(prevState.brew.text)
+		}));
 
 		request
 			.put(`/api/update/${this.props.brew.editId}`)

--- a/client/homebrew/pages/editPage/editPage.jsx
+++ b/client/homebrew/pages/editPage/editPage.jsx
@@ -94,9 +94,7 @@ const EditPage = createClass({
 		this.setState((prevState)=>({
 			brew      : _.merge({}, prevState.brew, metadata),
 			isPending : true,
-		}), ()=>{
-			this.trySave();
-		});
+		}), ()=>this.trySave());
 
 	},
 
@@ -110,9 +108,7 @@ const EditPage = createClass({
 			brew       : _.merge({}, prevState.brew, { text: text }),
 			isPending  : true,
 			htmlErrors : htmlErrors
-		}));
-
-		this.trySave();
+		}), ()=>this.trySave());
 	},
 
 	hasChanges : function(){

--- a/client/homebrew/pages/printPage/printPage.jsx
+++ b/client/homebrew/pages/printPage/printPage.jsx
@@ -22,7 +22,9 @@ const PrintPage = createClass({
 
 	componentDidMount : function() {
 		if(this.props.query.local){
-			this.setState({ brewText: localStorage.getItem(this.props.query.local) });
+			this.setState((prevState, prevProps) => ({
+				brewText: localStorage.getItem(prevProps.query.local)
+			}));
 		}
 
 		if(this.props.query.dialog) window.print();

--- a/client/homebrew/pages/printPage/printPage.jsx
+++ b/client/homebrew/pages/printPage/printPage.jsx
@@ -22,8 +22,8 @@ const PrintPage = createClass({
 
 	componentDidMount : function() {
 		if(this.props.query.local){
-			this.setState((prevState, prevProps) => ({
-				brewText: localStorage.getItem(prevProps.query.local)
+			this.setState((prevState, prevProps)=>({
+				brewText : localStorage.getItem(prevProps.query.local)
 			}));
 		}
 

--- a/client/homebrew/pages/userPage/brewItem/brewItem.jsx
+++ b/client/homebrew/pages/userPage/brewItem/brewItem.jsx
@@ -38,7 +38,7 @@ const BrewItem = createClass({
 	renderEditLink : function(){
 		if(!this.props.brew.editId) return;
 
-		return <a href={`/edit/${this.props.brew.editId}`} target='_blank'>
+		return <a href={`/edit/${this.props.brew.editId}`} target='_blank' rel='noopener noreferrer'>
 			<i className='fa fa-pencil' />
 		</a>;
 	},
@@ -63,7 +63,7 @@ const BrewItem = createClass({
 			</div>
 
 			<div className='links'>
-				<a href={`/share/${brew.shareId}`} target='_blank'>
+				<a href={`/share/${brew.shareId}`} target='_blank' rel='noopener noreferrer'>
 					<i className='fa fa-share-alt' />
 				</a>
 				{this.renderEditLink()}

--- a/server.js
+++ b/server.js
@@ -3,7 +3,7 @@ const jwt = require('jwt-simple');
 const express = require('express');
 const app = express();
 
-app.use(express.static(`${__dirname}/build`));'';
+app.use(express.static(`${__dirname}/build`));
 app.use(require('body-parser').json({ limit: '25mb' }));
 app.use(require('cookie-parser')());
 

--- a/shared/homebrewery/renderWarnings/renderWarnings.jsx
+++ b/shared/homebrewery/renderWarnings/renderWarnings.jsx
@@ -32,15 +32,6 @@ const RenderWarnings = createClass({
 				</li>;
 			}
 		},
-		zoom : function(){
-			return false;
-			if(window.devicePixelRatio !== 1){
-				return <li key='zoom'>
-					<em>Your browser is zoomed. </em> <br />
-					This can cause content to jump columns.
-				</li>;
-			}
-		}
 	},
 	checkWarnings : function(){
 		const hideDismiss = localStorage.getItem(DISMISS_KEY);


### PR DESCRIPTION
I noticed that [LGTM.com](https://lgtm.com/projects/g/stolksdorf/homebrewery/) flags a number of issues, including [one introduced by me](https://lgtm.com/projects/g/stolksdorf/homebrewery/snapshot/326df47790748c5c6aa4478d003ecc80c107a760/files/client/homebrew/brewRenderer/brewRenderer.jsx#xf5d98af18451059e:1) in #679. (It turns out you're [not meant to access React state or props](https://lgtm.com/rules/1819283066/) directly when setting state.) While I was at it, I fixed a bunch of other warnings; commit-by-commit review might be more manageable than the whole diff.

There are two LGTM alerts this PR does not address, mostly because I'm not as familiar with Express as I'd like before making changes:

 - We use `cookie-parser` [without installing CSRF prevention middleware](https://lgtm.com/projects/g/stolksdorf/homebrewery/snapshot/326df47790748c5c6aa4478d003ecc80c107a760/files/server.js?sort=name&dir=ASC&mode=heatmap&showExcluded=false#xcebb61afef5afd27:1), which potentially allows CSRF attacks.
 - We use `auth` [without rate-limiting](https://lgtm.com/projects/g/stolksdorf/homebrewery/snapshot/326df47790748c5c6aa4478d003ecc80c107a760/files/server/admin.api.js?sort=name&dir=ASC&mode=heatmap&showExcluded=false#xd1dcb593420d99f8:1), which potentially allows DoS.

While neither of those seem like big concerns for this project, it's probably worth just adding the relevant Express middlewares, but I leave that to future work.

@stolksdorf, @calculuschild -- LGTM offers [PR integration](https://lgtm.com/help/lgtm/using-lgtm-analysis-continuous-integration), and will potentially report problems like this early if we enable it. I think that's worth doing; do you agree?