### PR TITLE
Change circleci mongo version to one that still exists

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       - image: circleci/node:8.9
-      - image: circleci/mongo:3.4.4
+      - image: circleci/mongo:3.4-jessie
 
     working_directory: ~/repo
 


### PR DESCRIPTION
According to [the tags list](https://hub.docker.com/r/circleci/mongo/tags/), the `3.4.4` tag no longer exists. I don't know if we particularly care about which tag to use, but `3.4-jessie` seems sufficiently close in spirit.