### PR TITLE
Add dockerization and example compose file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,6 @@
 node_modules
 npm-debug.log
+.git
+Dockerfile
+docker-compose.yml
+tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:8
+
+# Create app directory
+WORKDIR /usr/src/app
+
+# Bundle app source
+COPY . .
+
+ENV NODE_ENV=docker
+
+RUN yarn
+
+EXPOSE 8000
+CMD [ "yarn", "start" ]

--- a/config/docker.json
+++ b/config/docker.json
@@ -1,0 +1,4 @@
+{
+	"mongodb_uri" : "mongodb://mongodb:27017/homebrewery",
+	"secret" : "secret"
+}

--- a/config/docker.json
+++ b/config/docker.json
@@ -1,4 +1,0 @@
-{
-	"mongodb_uri" : "mongodb://mongodb:27017/homebrewery",
-	"secret" : "secret"
-}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,3 +13,5 @@ services:
       MONGODB_URI: mongodb://mongodb/homebrewery
     ports:
       - "8000:8000"
+volumes:
+  mongodata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   mongodb:
     image: mongo:latest
     volumes:
-      - /your/data/location:/data/db
+      - mongodata:/data/db
   homebrewery:
     build:
       context: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '2'
+services:
+  mongodb:
+    image: mongo:latest
+    volumes:
+      - /your/data/location:/data/db
+  homebrewery:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: homebrewery
+    environment:
+      MONGODB_URI: mongodb://mongodb/homebrewery
+    ports:
+      - "8000:8000"


### PR DESCRIPTION
This is my take on #734. I have compressed the docker file to reduce the amount of layers and fixed the compose volume definition. The .dockerignore file is used so that when copying the files into the container it ignores npm related things (not sure this is related here as we use yarn?).

Also, the docker.json file is here to define the mongodb connection, I saw in #734 that you can use environment variables, if this holds true we can safely ignore this file and I will remove it.

This is the config/dockerfile that is currently running at https://homebrewery.hoengg.tech/