### PR TITLE
Fix regression with updated Pico-Router

### DIFF
--- a/client/homebrew/homebrew.jsx
+++ b/client/homebrew/homebrew.jsx
@@ -82,7 +82,7 @@ const Homebrew = createClass({
 	},
 	render : function(){
 		return <div className='homebrew'>
-			<Router initialUrl={this.props.url}/>
+			<Router defaultUrl={this.props.url}/>
 		</div>;
 	}
 });


### PR DESCRIPTION
This variable name changed with the v2.0.0 of Pico-Router and it wasn't changed here. This was causing every page to display a  `<div class="homePage page">` rather than the appropriate `editPage` or `sharePage`. It just wasn't immediately noticeable since `homePage` and `editPage` are almost identical. The problem is clearly visible on `sharePage` however.

`homebrew.jsx` was set to always render a defaultUrl of ` ` which creates a `<div class="homePage page">` by default, overwriting the expected `<div>` on for the current url.