### PR TITLE
Fix metadata not working. Some earlier linting caused the handleField…

### DIFF
--- a/client/homebrew/editor/metadataEditor/metadataEditor.jsx
+++ b/client/homebrew/editor/metadataEditor/metadataEditor.jsx
@@ -68,7 +68,7 @@ const MetadataEditor = createClass({
 				<input
 					type='checkbox'
 					checked={_.includes(this.props.metadata.systems, val)}
-					onChange={this.handleSystem.bind(null, val)} />
+					onChange={(e)=>this.handleSystem(val, e)} />
 				{val}
 			</label>;
 		});
@@ -133,18 +133,18 @@ const MetadataEditor = createClass({
 				<label>title</label>
 				<input type='text' className='value'
 					value={this.props.metadata.title}
-					onChange={this.handleFieldChange.bind(null, 'title')} />
+					onChange={(e)=>this.handleFieldChange('title',e)} />
 			</div>
 			<div className='field description'>
 				<label>description</label>
 				<textarea value={this.props.metadata.description} className='value'
-					onChange={this.handleFieldChange.bind(null, 'description')} />
+					onChange={(e)=>this.handleFieldChange('description',e)} />
 			</div>
 			{/*}
 			<div className='field tags'>
 				<label>tags</label>
 				<textarea value={this.props.metadata.tags}
-					onChange={this.handleFieldChange.bind(null, 'tags')} />
+					onChange={(e)=>this.handleFieldChange('tags',e)} />
 			</div>
 			*/}
 

--- a/client/homebrew/editor/metadataEditor/metadataEditor.jsx
+++ b/client/homebrew/editor/metadataEditor/metadataEditor.jsx
@@ -68,7 +68,7 @@ const MetadataEditor = createClass({
 				<input
 					type='checkbox'
 					checked={_.includes(this.props.metadata.systems, val)}
-					onChange={()=>this.handleSystem(val)} />
+					onChange={this.handleSystem.bind(null, val)} />
 				{val}
 			</label>;
 		});
@@ -133,18 +133,18 @@ const MetadataEditor = createClass({
 				<label>title</label>
 				<input type='text' className='value'
 					value={this.props.metadata.title}
-					onChange={()=>this.handleFieldChange('title')} />
+					onChange={this.handleFieldChange.bind(null, 'title')} />
 			</div>
 			<div className='field description'>
 				<label>description</label>
 				<textarea value={this.props.metadata.description} className='value'
-					onChange={()=>this.handleFieldChange('description')} />
+					onChange={this.handleFieldChange.bind(null, 'description')} />
 			</div>
 			{/*}
 			<div className='field tags'>
 				<label>tags</label>
 				<textarea value={this.props.metadata.tags}
-					onChange={()=>this.handleFieldChange('tags')} />
+					onChange={this.handleFieldChange.bind(null, 'tags')} />
 			</div>
 			*/}
 

--- a/client/homebrew/editor/metadataEditor/metadataEditor.jsx
+++ b/client/homebrew/editor/metadataEditor/metadataEditor.jsx
@@ -133,18 +133,18 @@ const MetadataEditor = createClass({
 				<label>title</label>
 				<input type='text' className='value'
 					value={this.props.metadata.title}
-					onChange={(e)=>this.handleFieldChange('title',e)} />
+					onChange={(e)=>this.handleFieldChange('title', e)} />
 			</div>
 			<div className='field description'>
 				<label>description</label>
 				<textarea value={this.props.metadata.description} className='value'
-					onChange={(e)=>this.handleFieldChange('description',e)} />
+					onChange={(e)=>this.handleFieldChange('description', e)} />
 			</div>
 			{/*}
 			<div className='field tags'>
 				<label>tags</label>
 				<textarea value={this.props.metadata.tags}
-					onChange={(e)=>this.handleFieldChange('tags',e)} />
+					onChange={(e)=>this.handleFieldChange('tags', e)} />
 			</div>
 			*/}
 


### PR DESCRIPTION
Fix metadata not working. Some earlier linting caused the handleFieldChange and handleSystem functions to not have access to event data. Returning these to their pre-lint state for now, but there might be a more lint-friendly way to do this later.